### PR TITLE
Fix build for all targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-./Build
-./Outputs
-./idea
+Build
+Outputs
+.idea

--- a/Benchmarks/BoilerPlate/CMakeLists.txt
+++ b/Benchmarks/BoilerPlate/CMakeLists.txt
@@ -10,7 +10,7 @@ add_dependencies ("BoilerPlate.Benchmark" "BoilerPlate.Library")
 
 set_target_properties ("BoilerPlate.Benchmark" PROPERTIES
         INCLUDE_DIRECTORIES      "${CMAKE_SOURCE_DIR}/Headers"
-        LINK_DIRECTORIES         "${CMAKE_SOURCE_DIR}/Outputs/Coverage"
+        LINK_DIRECTORIES         "${OUTPUT_DIR}"
         LINK_LIBRARIES           "benchmark;benchmark_main;boilerplate"
         LIBRARY_OUTPUT_NAME      "${OUTPUT_NAME}"
         ARCHIVE_OUTPUT_NAME      "${OUTPUT_NAME}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,11 @@ set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_DIR})
 set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${OUTPUT_DIR})
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_DIR})
 
-# Executables
-add_subdirectory ("Sources/BoilerPlate/Executable")
-
 # Libraries
 add_subdirectory ("Sources/BoilerPlate/Library")
+
+# Executables
+add_subdirectory ("Sources/BoilerPlate/Executable")
 
 # Benchmarks
 add_subdirectory ("Benchmarks/BoilerPlate")

--- a/Sources/BoilerPlate/Executable/CMakeLists.txt
+++ b/Sources/BoilerPlate/Executable/CMakeLists.txt
@@ -10,7 +10,7 @@ add_dependencies ("BoilerPlate.Executable" "BoilerPlate.Library")
 
 set_target_properties ("BoilerPlate.Executable" PROPERTIES
         INCLUDE_DIRECTORIES      "${CMAKE_SOURCE_DIR}/Headers"
-        LINK_DIRECTORIES         "${CMAKE_SOURCE_DIR}/Outputs/${CMAKE_BUILD_TYPE}"
+        LINK_DIRECTORIES         "${OUTPUT_DIR}"
         LINK_LIBRARIES           "boilerplate"
         COMPILE_OPTIONS          ""
         LIBRARY_OUTPUT_NAME      "${OUTPUT_NAME}"

--- a/Sources/BoilerPlate/Library/CMakeLists.txt
+++ b/Sources/BoilerPlate/Library/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library ("BoilerPlate.Library" STATIC ${SOURCES})
 
 set_target_properties ("BoilerPlate.Library" PROPERTIES
         INCLUDE_DIRECTORIES      "${CMAKE_SOURCE_DIR}/Headers"
-        LINK_DIRECTORIES         "${CMAKE_SOURCE_DIR}/Outputs/${CMAKE_BUILD_TYPE}"
+        LINK_DIRECTORIES         "${OUTPUT_DIR}"
         LINK_LIBRARIES           ""
         COMPILE_OPTIONS          ""
         LIBRARY_OUTPUT_NAME      "${OUTPUT_NAME}"

--- a/Tests/BoilerPlate/CMakeLists.txt
+++ b/Tests/BoilerPlate/CMakeLists.txt
@@ -12,7 +12,7 @@ add_dependencies ("BoilerPlateTest" "BoilerPlate.Library")
 
 set_target_properties ("BoilerPlateTest" PROPERTIES
         INCLUDE_DIRECTORIES      "${CMAKE_SOURCE_DIR}/Headers"
-        LINK_DIRECTORIES         "${CMAKE_SOURCE_DIR}/Outputs/Coverage"
+        LINK_DIRECTORIES         "${OUTPUT_DIR}"
         LINK_LIBRARIES           "gtest;gtest_main;boilerplate"
         LIBRARY_OUTPUT_NAME      "${OUTPUT_NAME}"
         ARCHIVE_OUTPUT_NAME      "${OUTPUT_NAME}"


### PR DESCRIPTION
The build system did not work because it did not found the proper library that was in another directory. Here's a fix to properly give the right dependencies.